### PR TITLE
Fix compilation with Clang.

### DIFF
--- a/src/ios_webkit_debug_proxy_main.c
+++ b/src/ios_webkit_debug_proxy_main.c
@@ -52,7 +52,7 @@ int main(int argc, char** argv) {
   int ret = iwdpm_configure(self, argc, argv);
   if (ret) {
     exit(ret > 0 ? ret : 0);
-    return;
+    return ret;
   }
 
   iwdpm_create_bridge(self);


### PR DESCRIPTION
Always return int, to fix the following error while compiling with Clang:
ios_webkit_debug_proxy_main.c:55:5: error: non-void function 'main' should return a value [-Wreturn-type]
    return;
