### PR TITLE
Fixes WebSocket frame length too large error

### DIFF
--- a/src/websocket.c
+++ b/src/websocket.c
@@ -16,6 +16,15 @@
 
 #include "validate_utf8.h"
 
+#ifndef htobe64
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define htobe64(h) OSSwapHostToBigInt64(h)
+#elif _MSC_VER
+#define htobe64(h) _byteswap_uint64(h)
+#endif
+#endif
+
 typedef int8_t ws_state;
 #define STATE_ERROR 1
 #define STATE_READ_HTTP_REQUEST 2

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -304,9 +304,18 @@ ws_status ws_send_frame(ws_t self,
   *out_tail++ = ((is_masking ? 0x80 : 0) | (!payload_n ? payload_length :
         payload_n == 2 ? 126: 127));
 
-  int8_t j;
-  for (j = payload_n - 1; j >= 0; j--) {
-    *out_tail++ = (unsigned char)((payload_length >> (j<<3)) & 0xFF);
+  if (payload_n != 0) {
+    if (payload_n == 2) {
+        uint16_t sz16 = htons(payload_length);
+        memcpy(out_tail, &sz16, payload_n);
+    } else {
+        uint64_t sz64 = htobe64(payload_length);
+        memcpy(out_tail, &sz64, payload_n);
+    }
+
+    int i;
+    for (i = 0; i < payload_n; i++) 
+      *out_tail++;
   }
 
   if (is_masking) {


### PR DESCRIPTION
Fix for issue #29 WebSocket frame length too large. The cause of the issue is incorrect encapsulation of websocket packets larger than 64kb.