### PR TITLE
Swaps cases in conditional print on stolen page

### DIFF
--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -1093,7 +1093,7 @@ ws_status iwdp_on_frame(ws_t ws,
         char *s;
         if (asprintf(&s, "Page %d/%d %s%s", iport->port, iws->page_num,
             (p ? "claimed by " : "not found"),
-            (p ? "" : (p->iws ? "local" : "remote"))) < 0) {
+            (p ? (p->iws ? "local" : "remote") : "" )) < 0) {
           return ws->on_error(ws, "asprintf failed");
         }
         ws->on_error(ws, "%s", s);


### PR DESCRIPTION
On a stolen page, if p is null then conditional print tries to
access p->iws, which will segfault.
In the usual case, it prints `27753/1 claimed by `.  This will fix it to `27753/1 claimed by local`.