### PR TITLE
revert default frontend to 18.0.1025.74

### DIFF
--- a/src/ios_webkit_debug_proxy_main.c
+++ b/src/ios_webkit_debug_proxy_main.c
@@ -208,7 +208,7 @@ int iwdpm_configure(iwdpm_t self, int argc, char **argv) {
   };
   const char *DEFAULT_CONFIG = "null:9221,:9222-9322";
   const char *DEFAULT_FRONTEND =
-     "chrome-devtools://devtools/bundled/devtools.html";
+     "http://chrome-devtools-frontend.appspot.com/static/18.0.1025.74/devtools.html";
 
   self->config = strdup(DEFAULT_CONFIG);
   self->frontend = strdup(DEFAULT_FRONTEND);


### PR DESCRIPTION
Looks like only original version `18.0.1025.74` of devtools work with current `ios-webkit-debug-proxy`. 
Version that I tried not working properly: 
- http://chrome-devtools-frontend.appspot.com/static/27.0.1453.93/devtools.html, very slow, safari crash on breakpoint
- http://chrome-devtools-frontend.appspot.com/static/25.0.1364.169/devtools.html, very slow, safari crash on breakpoint
- chrome-devtools://devtools/bundled/devtools.html in chrome 40.0.2214.94, empty content

We can force frontend by run 
```
ios_webkit_debug_proxy -f http://chrome-devtools-frontend.appspot.com/static/18.0.1025.74/devtools.html
```
But it may reduce lots of confusion if the default can work.

cc @addyosmani @paulirish 