### PR TITLE
Fixes unused value error when incrementing pointer

### DIFF
--- a/src/websocket.c
+++ b/src/websocket.c
@@ -324,7 +324,7 @@ ws_status ws_send_frame(ws_t self,
 
     int i;
     for (i = 0; i < payload_n; i++) 
-      *out_tail++;
+      out_tail++;
   }
 
   if (is_masking) {


### PR DESCRIPTION
out_tail is being incremented for the size of the payload, but
*out_tail++ returns the value, which causes unused value error on build

For #104, @artygus can you double check if this is what you wanted to do in your PR?