### PR TITLE
build: link against -lm to get log10 symbol

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AC_PROG_INSTALL
 PKG_CHECK_MODULES(libimobiledevice, libimobiledevice-1.0 >= 1.2.0)
 PKG_CHECK_MODULES(libplist, libplist >= 1.11)
 AC_CHECK_LIB([plist], [plist_to_xml], [ ])
-AC_CHECK_LIB([m], [log10], [ ])
+AC_CHECK_LIB([m], [log10])
 AC_CHECK_LIB([imobiledevice], [idevice_new], [ ])
 LT_INIT
 


### PR DESCRIPTION
`./configure.ac` is checking for `log10()` symbol in `libm` but doesn't
do anything if found. If `log10()` is present when linking with `libm`,
we want to link with `libm`, hence we keep the default of `AC_CHECK_LIB`
to add it to `LIBS`.

(edited: my previous solution was wrong)