### PR TITLE
build: make plist/imobiledevice lib check more useful

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,9 +17,13 @@ AC_PROG_INSTALL
 # Checks for libraries.
 PKG_CHECK_MODULES(libimobiledevice, libimobiledevice-1.0 >= 1.2.0)
 PKG_CHECK_MODULES(libplist, libplist >= 1.11)
-AC_CHECK_LIB([plist], [plist_to_xml], [ ])
+AC_CHECK_LIB([plist], [plist_to_xml],
+             [ ], [AC_MSG_FAILURE([*** Unable to link with libplist])],
+             [$libplist_LIBS])
 AC_CHECK_LIB([m], [log10])
-AC_CHECK_LIB([imobiledevice], [idevice_new], [ ])
+AC_CHECK_LIB([imobiledevice], [idevice_new],
+             [ ], [AC_MSG_FAILURE([*** Unable to link with libimobiledevice])],
+             [$libimobiledevice_LIBS])
 LT_INIT
 
 # Checks for header files.


### PR DESCRIPTION
The current checks for plist and imobiledevice were a bit useless. If
they were found, nothing was done. And if they weren't, nothing was done
either. We could just drop the tests since we should be able to trust
`PKG_CHECK_MODULES`.

As an alternative, this commit triggers a failure if the link is
unsuccessful. It also ensures that linking can be done when the libs are
located in some unstandard directory.

This PR will conflict with #111. I'll rebase if it gets merged.