### PR TITLE
git: ignore more autotools files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ aclocal.m4
 autom4te.cache
 autoscan.log
 compile
+config.guess
+config.sub
 config.h
 config.h.in
 config.log
@@ -24,6 +26,7 @@ config.status
 configure
 configure.scan
 depcomp
+ltmain.sh
 install-sh
 missing
 stamp-h1


### PR DESCRIPTION
When autogen is run, it also generates `config.guess`, `config.sub` and
`ltmain.sh`. Let's ignore them.