### PR TITLE
DevTools frontend: change default from v18 to v27

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # iOS WebKit Debug Proxy
 
-The ios_webkit_debug_proxy (aka _iwdp_) allows developers to inspect MobileSafari and UIWebViews on real and simulated iOS devices via the [Chrome DevTools UI](https://developers.google.com/chrome-developer-tools/) and [Chrome Remote Debugging Protocol](https://developer.chrome.com/devtools/docs/debugger-protocol).  DevTools requests are translated into Apple's [Remote Web Inspector service](https://developer.apple.com/technologies/safari/developer-tools.html) calls. 
+The ios_webkit_debug_proxy (aka _iwdp_) allows developers to inspect MobileSafari and UIWebViews on real and simulated iOS devices via the [Chrome DevTools UI](https://developers.google.com/chrome-developer-tools/) and [Chrome Remote Debugging Protocol](https://developer.chrome.com/devtools/docs/debugger-protocol).  DevTools requests are translated into Apple's [Remote Web Inspector service](https://developer.apple.com/technologies/safari/developer-tools.html) calls.
 
 ## Installation
 
@@ -52,14 +52,14 @@ Your attached iOS devices must have ≥1 open browser tabs and the inspector ena
 ios_webkit_debug_proxy
 ```
 
-* `--debug` for verbose output.  
+* `--debug` for verbose output.
 * `--frontend` to specify a frontend
 * `--help` for more options.
-* `Ctrl-C` to quit. Also, the proxy can be left running as a background process.  
+* `Ctrl-C` to quit. Also, the proxy can be left running as a background process.
 
 ### View and inspect debuggable tabs
 
-Navigate to [localhost:9221](http://localhost:9221). You'll see a listing of all connected devices. 
+Navigate to [localhost:9221](http://localhost:9221). You'll see a listing of all connected devices.
 
 Click through to view tabs available on each, and click through again to open the DevTools for a tab.
 
@@ -69,7 +69,7 @@ Click through to view tabs available on each, and click through again to open th
 
 By default, the DevTools UI frontend that iwdp uses is from:
 
-    http://chrome-devtools-frontend.appspot.com/static/18.0.1025.74/devtools.html
+    http://chrome-devtools-frontend.appspot.com/static/27.0.1453.93/devtools.html
 
 You can use the `-f` argument to specify different frontend source, like Chrome's local DevTools, a local
 [Chromium checkout](https://chromium.googlesource.com/chromium/src/+/master/third_party/WebKit/Source/devtools/) or another URL:
@@ -80,7 +80,7 @@ ios_webkit_debug_proxy -f chrome-devtools://devtools/bundled/inspector.html
 ios_webkit_debug_proxy -f ~/chromium/src/third_party/WebKit/Source/devtools/front_end/inspector.html
 ios_webkit_debug_proxy -f http://foo.com:1234/bar/inspector.html
 ```
- 
+
 If you use `-f chrome-devtools://devtools/bundled/inspector.html`, you won't be able to click the links shown in `localhost:9222` as Chrome blocks clicking these URLs. However, you can copy/paste them into the address bar.
 
 Just the same, you can apply the appropriate port (9222) and page (2) values below.
@@ -88,7 +88,7 @@ Just the same, you can apply the appropriate port (9222) and page (2) values bel
     chrome-devtools://devtools/bundled/inspector.html?ws=localhost:9222/devtools/page/1
 
 The `-f` value must end in ".html". As of Chrome 45, the primary URL [changed](https://codereview.chromium.org/1144393004/) from `devtools.html` to `inspector.html`.
- 
+
 To disable the frontend proxy, use the `--no-frontend` argument.
 
 #### Port assigment
@@ -100,7 +100,7 @@ The default configuration works well for most developers. The device_id-to-port 
     :9223 for the second iOS device that is attached
     ...
     :9322 for the max device
-      
+
 If a port is in use then the next available port will be used, up to the range limit.
 
 The port assignment is first-come-first-serve but is preserved if a device is detached and reattached, assuming that the proxy is not restarted, e.g.:
@@ -142,7 +142,7 @@ See [design.md](design.md) for an overview of the source layout and architecture
 
 ## License and Copyright
 
-Google BSD license <http://code.google.com/google_bsd_license.html>   
+Google BSD license <http://code.google.com/google_bsd_license.html>
 Copyright 2012 Google Inc.  <wrightt@google.com>
 
 The proxy uses the following open-source packages:

--- a/src/ios_webkit_debug_proxy_main.c
+++ b/src/ios_webkit_debug_proxy_main.c
@@ -208,7 +208,7 @@ int iwdpm_configure(iwdpm_t self, int argc, char **argv) {
   };
   const char *DEFAULT_CONFIG = "null:9221,:9222-9322";
   const char *DEFAULT_FRONTEND =
-     "http://chrome-devtools-frontend.appspot.com/static/18.0.1025.74/devtools.html";
+     "http://chrome-devtools-frontend.appspot.com/static/27.0.1453.93/devtools.html";
 
   self->config = strdup(DEFAULT_CONFIG);
   self->frontend = strdup(DEFAULT_FRONTEND);


### PR DESCRIPTION
Based on the thread in #86 it sounds like the default should be changed.

Any objections?