### PR TITLE
Support building with Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.la
 .deps
 .libs
+*.exe
 src/ios_webkit_debug_proxy
 examples/dl_client
 examples/wi_client

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ libtool
 
 # Vim
 *.sw[o-p]
+
+# Files used by the Visual Studio build
+ext/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+before_build:
+  - cmd: mkdir ext
+  - cmd: choco install -y wget
+  - cmd: wget "http://downloads.sourceforge.net/project/gnuwin32/pcre/7.0/pcre-7.0-bin.zip" -O ext\pcre-7.0-bin.zip
+  - cmd: wget "http://downloads.sourceforge.net/project/gnuwin32/pcre/7.0/pcre-7.0-lib.zip" -O ext\pcre-7.0-lib.zip
+  - cmd: 7z x ext\pcre-7.0-bin.zip -oext\pcre-7.0-bin
+  - cmd: 7z x ext\pcre-7.0-lib.zip -oext\pcre-7.0-lib
+  - cmd: cd msvc
+  - cmd: nuget restore
+
+build_script:
+  - msbuild ios-webkit-debug-proxy.sln /p:Configuration=Debug /p:Platform=x86 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+on_success:
+  - cmd: wget http://coapp.org/files/CoApp.Tools.Powershell.msi
+  - cmd: start /wait msiexec /qb /i CoApp.Tools.Powershell.msi
+  - ps: .\CreateNuGetPackage.ps1 -Build $ENV:APPVEYOR_BUILD_NUMBER
+  - cmd: appveyor PushArtifact ios-webkit-debug-proxy.1.6.%APPVEYOR_BUILD_NUMBER%.nupkg
+  - cmd: appveyor PushArtifact ios-webkit-debug-proxy.symbols.1.6.%APPVEYOR_BUILD_NUMBER%.nupkg
+  - cmd: appveyor PushArtifact ios-webkit-debug-proxy.redist.1.6.%APPVEYOR_BUILD_NUMBER%.nupkg
+
+nuget:
+  project_feed: true
+  account_feed: true

--- a/configure.ac
+++ b/configure.ac
@@ -41,9 +41,34 @@ AC_TYPE_UINT64_T
 AC_TYPE_UINT8_T
 
 # Checks for library functions.
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
-AC_CHECK_FUNCS([memmove memset regcomp select socket stpcpy strcasecmp strncasecmp strchr strdup strndup strrchr strstr strtol])
+AC_CHECK_FUNCS([malloc realloc memmove memset regcomp select socket stpcpy strcasecmp strncasecmp strchr strdup strndup strrchr strstr strtol strcasestr va_copy vasprintf asprintf stpncpy stpcpy strndup getline htobe64])
+
+# Check for pcre presence if regex.h is absent
+AC_CHECK_HEADER(regex.h, [ac_have_regex_h="yes"], [ac_have_regex_h="no"])
+if test "x$ac_have_regex_h" = "xno"; then
+  PKG_CHECK_MODULES(libpcreposix, libpcreposix, [], [AC_MSG_ERROR([Neither regex.h nor pcre headers were found])])
+else
+  AC_DEFINE(HAVE_REGEX_H, 1, [regex.h is present])
+fi
+
+# Check for operating system
+AC_MSG_CHECKING([whether to enable WIN32 build settings])
+case ${host_os} in
+  *mingw32*|*cygwin*)
+    win32=true
+    AC_MSG_RESULT([yes])
+    AC_DEFINE(WIN32_LEAN_AND_MEAN, 1, [Define to limit the scope of windows.h])
+    AC_DEFINE(__USE_MINGW_ANSI_STDIO, 1, [Define to use C99 printf/snprintf in MinGW])
+    ;;
+  *)
+    win32=false
+    AC_MSG_RESULT([no])
+    ;;
+esac
+AM_CONDITIONAL(WIN32, test x$win32 = xtrue)
+
+# Check endianess
+AC_C_BIGENDIAN
 
 AC_CONFIG_FILES([Makefile src/Makefile include/Makefile examples/Makefile])
 

--- a/examples/dl_client.c
+++ b/examples/dl_client.c
@@ -4,12 +4,20 @@
 //
 // An example device_listener client
 //
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
 
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef WIN32
+#include <windows.h>
+#include <winsock2.h>
+#else
 #include <sys/socket.h>
+#endif
 #include <unistd.h>
 
 #include "device_listener.h"
@@ -66,7 +74,11 @@ int main(int argc, char** argv) {
       break;
     }
   }
+#ifndef WIN32
   close(fd);
+#else
+  closesocket(fd);
+#endif
   free(dl->state);
   dl_free(dl);
   return 0;

--- a/examples/wi_client.c
+++ b/examples/wi_client.c
@@ -4,6 +4,9 @@
 //
 // A minimal webinspector client
 //
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
 
 #include <errno.h>
 #include <signal.h>
@@ -11,7 +14,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef WIN32
+#include <windows.h>
+#include <winsock2.h>
+#else
 #include <sys/socket.h>
+#endif
 #include <unistd.h>
 
 #include "webinspector.h"
@@ -121,7 +129,11 @@ int main(int argc, char **argv) {
   size_t buf_length = 1024;
   while (!quit_flag) {
     ssize_t read_bytes = recv(fd, buf, buf_length, 0);
+#ifndef WIN32
     if (read_bytes < 0 && errno == EWOULDBLOCK) {
+#else
+    if (read_bytes && WSAGetLastError() != WSAEWOULDBLOCK) {
+#endif
       continue;
     }
     if (wi->on_recv(wi, buf, read_bytes)) {
@@ -135,7 +147,11 @@ int main(int argc, char **argv) {
   memset(my_wi, 0, sizeof(struct my_wi_struct));
   free(my_wi);
   if (fd >= 0) {
+#ifndef WIN32
     close(fd);
+#else
+    closesocket(fd);
+#endif
   }
   return 0;
 }

--- a/examples/ws_echo1.c
+++ b/examples/ws_echo1.c
@@ -4,6 +4,9 @@
 //
 // A minimal websocket "echo" server
 //
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -12,9 +15,14 @@
 #include "ws_echo_common.h"
 #include "websocket.h"
 
+#ifdef WIN32
+#include <windows.h>
+#include <winsock2.h>
+#else
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#endif
 #include <errno.h>
 #include <unistd.h>
 
@@ -22,6 +30,13 @@
 #define PORT 8080
 
 int main(int argc, char** argv) {
+#ifdef WIN32
+  WSADATA wsa_data;
+  if (WSAStartup(MAKEWORD(2,2), &wsa_data) != ERROR_SUCCESS) {
+    fprintf(stderr, "WSAStartup failed!\n");
+    ExitProcess(-1);
+  }
+#endif
   int port = PORT;
 
   int sfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -38,7 +53,11 @@ int main(int argc, char** argv) {
       bind(sfd, (struct sockaddr*)&local, sizeof(local)) < 0 ||
       listen(sfd, 1)) {
     perror("Unable to bind");
+#ifndef WIN32
     close(sfd);
+#else
+    closesocket(sfd);
+#endif
     return -1;
   }
 
@@ -65,10 +84,18 @@ int main(int argc, char** argv) {
         break;
       }
     }
+#ifndef WIN32
     close(fd);
+#else
+    closesocket(fd);
+#endif
     my_free(my);
   }
 
+#ifndef WIN32
   close(sfd);
+#else
+  closesocket(sfd);
+#endif
   return ret;
 }

--- a/examples/ws_echo2.c
+++ b/examples/ws_echo2.c
@@ -4,6 +4,9 @@
 //
 // A select-based websocket "echo" server
 //
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
 
 #include <signal.h>
 #include <stdbool.h>
@@ -12,8 +15,13 @@
 #include <string.h>
 #include <assert.h>
 
+#ifdef WIN32
+#include <windows.h>
+#include <winsock2.h>
+#else
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#endif
 #include <errno.h>
 
 #include "socket_manager.h"

--- a/examples/ws_echo_common.c
+++ b/examples/ws_echo_common.c
@@ -4,17 +4,25 @@
 //
 // A minimal websocket "echo" server
 //
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
 
 #define _GNU_SOURCE
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef WIN32
+#include <windows.h>
+#include <winsock2.h>
+#else
 #include <sys/socket.h>
+#endif
 
 #include "ws_echo_common.h"
 #include "websocket.h"
-
+#include "asprintf.h"
 
 // websocket callbacks:
 

--- a/include/asprintf.h
+++ b/include/asprintf.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2004 Darren Tucker.
+ *
+ * Based originally on asprintf.c from OpenBSD:
+ * Copyright (c) 1997 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef __ASPRINTF_H
+#define __ASPRINTF_H
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdarg.h>
+#include <limits.h>
+
+#ifndef HAVE_VASPRINTF
+
+#ifndef VA_COPY
+# ifdef HAVE_VA_COPY
+#  define VA_COPY(dest, src) va_copy(dest, src)
+# else
+#  ifdef HAVE___VA_COPY
+#   define VA_COPY(dest, src) __va_copy(dest, src)
+#  else
+#   define VA_COPY(dest, src) (dest) = (src)
+#  endif
+# endif
+#endif
+
+#define INIT_SZ 128
+
+static inline int vasprintf(char **str, const char *fmt, va_list ap)
+{
+  int ret = -1;
+  va_list ap2;
+  char *string, *newstr;
+  size_t len;
+
+  VA_COPY(ap2, ap);
+  if ((string = malloc(INIT_SZ)) == NULL)
+    goto fail;
+
+  ret = vsnprintf(string, INIT_SZ, fmt, ap2);
+  if (ret >= 0 && ret < INIT_SZ) { /* succeeded with initial alloc */
+    *str = string;
+  } else if (ret == INT_MAX || ret < 0) { /* Bad length */
+    free(string);
+    goto fail;
+  } else {  /* bigger than initial, realloc allowing for nul */
+    len = (size_t)ret + 1;
+    if ((newstr = realloc(string, len)) == NULL) {
+      free(string);
+      goto fail;
+    } else {
+      va_end(ap2);
+      VA_COPY(ap2, ap);
+      ret = vsnprintf(newstr, len, fmt, ap2);
+      if (ret >= 0 && (size_t)ret < len) {
+        *str = newstr;
+      } else { /* failed with realloc'ed string, give up */
+        free(newstr);
+        goto fail;
+      }
+    }
+  }
+  va_end(ap2);
+  return (ret);
+
+fail:
+  *str = NULL;
+  va_end(ap2);
+  return (-1);
+}
+#endif
+
+#ifndef HAVE_ASPRINTF
+static inline int asprintf(char **str, const char *fmt, ...)
+{
+  va_list ap;
+  int ret;
+
+  *str = NULL;
+  va_start(ap, fmt);
+  ret = vasprintf(str, fmt, ap);
+  va_end(ap);
+
+  return ret;
+}
+#endif
+
+#endif

--- a/include/getline.h
+++ b/include/getline.h
@@ -1,0 +1,53 @@
+/* Copyright (C) 1991, 1992, 1995, 1996, 1997 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, write to the Free
+   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307 USA.  */
+
+#ifndef __GETLINE_H
+#define __GETLINE_H
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef HAVE_GETLINE
+static inline int getline(char **lineptr, size_t *n, FILE *stream)
+{
+  if (lineptr == NULL || n == NULL)
+  {
+    return -1;
+  }
+  if (*lineptr == NULL || *n == 0)
+  {
+    *n = 120;
+    *lineptr = (char *) malloc (*n);
+    if (*lineptr == NULL)
+    {
+      return -1;
+    }
+  }
+  if (fgets (*lineptr, *n, stream))
+    return *n;
+  else
+    return -1;
+}
+#endif
+
+#endif

--- a/include/rpc.h
+++ b/include/rpc.h
@@ -13,6 +13,7 @@ extern "C" {
 #endif
 
 #include <plist/plist.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/include/stpcpy.h
+++ b/include/stpcpy.h
@@ -1,0 +1,36 @@
+/* Implement the stpcpy function.
+   Copyright (C) 2003 Free Software Foundation, Inc.
+   Written by Kaveh R. Ghazi <ghazi@caip.rutgers.edu>.
+
+   This file is part of the libiberty library.
+   Libiberty is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   Libiberty is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with libiberty; see the file COPYING.LIB.  If
+   not, write to the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+   Boston, MA 02110-1301, USA.  */
+
+#ifndef __STPCPY_H
+#define __STPCPY_H
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#ifndef HAVE_STPCPY
+static inline char* stpcpy(char *dst, const char *src)
+{
+  const size_t len = strlen (src);
+  return (char *) memcpy (dst, src, len + 1) + len;
+}
+#endif
+
+#endif

--- a/include/stpncpy.h
+++ b/include/stpncpy.h
@@ -1,0 +1,38 @@
+/* Implement the stpncpy function.
+   Copyright (C) 2003, 2011 Free Software Foundation, Inc.
+   Written by Kaveh R. Ghazi <ghazi@caip.rutgers.edu>.
+
+   This file is part of the libiberty library.
+   Libiberty is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   Libiberty is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with libiberty; see the file COPYING.LIB.  If
+   not, write to the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+   Boston, MA 02110-1301, USA.  */
+
+#ifndef __STPNCPY_H
+#define __STPNCPY_H
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#ifndef HAVE_STPNCPY
+static inline char* stpncpy(char *dst, const char *src, size_t len)
+{
+  size_t n = strlen (src);
+  if (n > len)
+    n = len;
+  return strncpy (dst, src, len) + n;
+}
+#endif
+
+#endif

--- a/include/strcasestr.h
+++ b/include/strcasestr.h
@@ -1,0 +1,68 @@
+/*-
+ * Copyright (c) 1990, 1993
+ * The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Chris Torek.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *  This product includes software developed by the University of
+ * California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef __STRCASESTR_H
+#define __STRCASESTR_H
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <ctype.h>
+#include <string.h>
+
+#ifndef HAVE_STRCASESTR
+static inline char* strcasestr(const char *s, const char *find)
+{
+  char c, sc;
+  size_t len;
+
+  if ((c = *find++) != 0) {
+    c = tolower((unsigned char)c);
+    len = strlen(find);
+    do {
+      do {
+        if ((sc = *s++) == 0)
+          return (NULL);
+      } while ((char)tolower((unsigned char)sc) != c);
+    } while (strncasecmp(s, find, len) != 0);
+    s--;
+  }
+  return ((char *)s);
+}
+#endif
+
+#endif

--- a/include/strndup.h
+++ b/include/strndup.h
@@ -1,0 +1,48 @@
+/* Implement the strndup function.
+   Copyright (C) 2005 Free Software Foundation, Inc.
+   Written by Kaveh R. Ghazi <ghazi@caip.rutgers.edu>.
+
+   This file is part of the libiberty library.
+   Libiberty is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   Libiberty is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with libiberty; see the file COPYING.LIB.  If
+   not, write to the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+   Boston, MA 02110-1301, USA.  */
+
+#ifndef __STRNDUP_H
+#define __STRNDUP_H
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <string.h>
+
+#ifndef HAVE_STRNDUP
+static inline char* strndup(const char *s, size_t n)
+{
+  char *result;
+  size_t len = strlen (s);
+
+  if (n < len)
+    len = n;
+
+  result = (char *) malloc (len + 1);
+  if (!result)
+    return 0;
+
+  result[len] = '\0';
+  return (char *) memcpy (result, s, len);
+}
+#endif
+
+#endif

--- a/msvc/.gitignore
+++ b/msvc/.gitignore
@@ -1,0 +1,5 @@
+Debug
+packages
+.vs
+*.opendb
+*.db

--- a/msvc/CreateNuGetPackage.ps1
+++ b/msvc/CreateNuGetPackage.ps1
@@ -1,0 +1,12 @@
+Param(
+  [string]$build
+)
+
+Write-Host Changing build number to $build
+
+# Update the build number
+(gc .\ios-webkit-debug-proxy.autoconfig).replace('{build}', $build)|sc .\ios-webkit-debug-proxy.out.autoconfig
+
+# Create the NuGet package
+Import-Module "C:\Program Files (x86)\Outercurve Foundation\modules\CoApp"
+Write-NuGetPackage .\ios-webkit-debug-proxy.out.autoconfig

--- a/msvc/config.h
+++ b/msvc/config.h
@@ -6,4 +6,13 @@ typedef SSIZE_T ssize_t;
 
 // The 'bool' type is used by various files, so include it.
 #include <stdbool.h>
+
+// Map string functions to their VC++ equivalent.
+#ifndef strncasecmp
+#define strncasecmp strnicmp
+#endif
+
+#ifndef strcasecmp
+#define strcasecmp stricmp
+#endif
 #endif

--- a/msvc/config.h
+++ b/msvc/config.h
@@ -1,0 +1,9 @@
+#if defined(_MSC_VER)
+
+// Define ssize_t (as SSIZE_T)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+
+// The 'bool' type is used by various files, so include it.
+#include <stdbool.h>
+#endif

--- a/msvc/ios-webkit-debug-proxy.autoconfig
+++ b/msvc/ios-webkit-debug-proxy.autoconfig
@@ -1,0 +1,36 @@
+configurations {
+    Toolset { 
+        key : "PlatformToolset"; 
+        choices: { v140 };  
+        // Explicitly Not including pivot variants:  "WindowsKernelModeDriver8.0", "WindowsApplicationForDrivers8.0", "WindowsUserModeDriver8.0" 
+
+        // We're normalizing out the concept of the v140 platform -- Overloading the $(PlatformToolset) variable for additional pivots was a dumb idea.
+        v140.condition = "( $(PlatformToolset.ToLower().IndexOf('v140')) > -1 Or '$(PlatformToolset.ToLower())' == 'windowskernelmodedriver8.0' Or '$(PlatformToolset.ToLower())' == 'windowsapplicationfordrivers8.0' Or '$(PlatformToolset.ToLower())' == 'windowsusermodedriver8.0' )";
+    };
+}
+
+nuget{
+    nuspec{
+        id = ios-webkit-debug-proxy;
+        version : 1.6.{build};
+        title: ios-webkit-debug-proxy;
+        authors: {ios-webkit-debug-proxy Project};
+        owners: {quamotion};
+        licenseUrl: "https://github.com/google/ios-webkit-debug-proxy/blob/master/LICENSE.md";
+        projectUrl: "hhttps://github.com/google/ios-webkit-debug-proxy";
+        iconUrl: "http://www.nuget.org/Content/Images/packageDefaultIcon-50x50.png";
+        requireLicenseAcceptance:false;
+        description: "The ios_webkit_debug_proxy (aka iwdp) allows developers to inspect MobileSafari and UIWebViews on real and simulated iOS devices via the Chrome DevTools UI and Chrome Remote Debugging Protocol.";
+        summary: "The ios_webkit_debug_proxy (aka iwdp) allows developers to inspect MobileSafari and UIWebViews on real and simulated iOS devices via the Chrome DevTools UI and Chrome Remote Debugging Protocol.";
+        copyright: "https://github.com/google/ios-webkit-debug-proxy/blob/master/LICENSE.md";
+        releaseNotes: "Release 1.6 of ios-webkit-debug-proxy. See https://github.com/libimobiledevice-win32/ios-webkit-debug-proxy for more.";
+        tags: { ios-webkit-debug-proxy, native };
+    }
+
+    files{
+	[x86,v140,debug] {
+            bin: { "Debug\ios-webkit-debug-proxy.exe", "Debug\*.dll" };
+            symbols: Debug\ios-webkit-debug-proxy.pdb;
+        }
+    }
+}

--- a/msvc/ios-webkit-debug-proxy.sln
+++ b/msvc/ios-webkit-debug-proxy.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ios-webkit-debug-proxy", "ios-webkit-debug-proxy\ios-webkit-debug-proxy.vcxproj", "{21DAC937-6A81-4ED6-8D04-388A81EF02C2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{21DAC937-6A81-4ED6-8D04-388A81EF02C2}.Debug|x64.ActiveCfg = Debug|x64
+		{21DAC937-6A81-4ED6-8D04-388A81EF02C2}.Debug|x64.Build.0 = Debug|x64
+		{21DAC937-6A81-4ED6-8D04-388A81EF02C2}.Debug|x86.ActiveCfg = Debug|Win32
+		{21DAC937-6A81-4ED6-8D04-388A81EF02C2}.Debug|x86.Build.0 = Debug|Win32
+		{21DAC937-6A81-4ED6-8D04-388A81EF02C2}.Release|x64.ActiveCfg = Release|x64
+		{21DAC937-6A81-4ED6-8D04-388A81EF02C2}.Release|x64.Build.0 = Release|x64
+		{21DAC937-6A81-4ED6-8D04-388A81EF02C2}.Release|x86.ActiveCfg = Release|Win32
+		{21DAC937-6A81-4ED6-8D04-388A81EF02C2}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/msvc/ios-webkit-debug-proxy.sln
+++ b/msvc/ios-webkit-debug-proxy.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ios-webkit-debug-proxy", "ios-webkit-debug-proxy\ios-webkit-debug-proxy.vcxproj", "{21DAC937-6A81-4ED6-8D04-388A81EF02C2}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ios-webkit-debug-proxy", "ios-webkit-debug-proxy.vcxproj", "{21DAC937-6A81-4ED6-8D04-388A81EF02C2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/msvc/ios-webkit-debug-proxy.vcxproj
+++ b/msvc/ios-webkit-debug-proxy.vcxproj
@@ -107,7 +107,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;$(ProjectDir)..\ext\pcre-7.0-lib\lib\pcre.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -121,7 +121,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;$(ProjectDir)..\ext\pcre-7.0-lib\lib\pcre.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -139,7 +139,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;$(ProjectDir)..\ext\pcre-7.0-lib\lib\pcre.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -157,7 +157,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;$(ProjectDir)..\ext\pcre-7.0-lib\lib\pcre.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/msvc/ios-webkit-debug-proxy.vcxproj
+++ b/msvc/ios-webkit-debug-proxy.vcxproj
@@ -1,0 +1,158 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{21DAC937-6A81-4ED6-8D04-388A81EF02C2}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ioswebkitdebugproxy</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="ios-webkit-debug-proxy.cpp" />
+    <ClCompile Include="stdafx.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/ios-webkit-debug-proxy.vcxproj
+++ b/msvc/ios-webkit-debug-proxy.vcxproj
@@ -207,4 +207,15 @@
     <Error Condition="!Exists('packages\pcre.redist.8.32.0.7\build\native\pcre.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\pcre.redist.8.32.0.7\build\native\pcre.redist.targets'))" />
     <Error Condition="!Exists('packages\pcre.8.32.0.7\build\native\pcre.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\pcre.8.32.0.7\build\native\pcre.targets'))" />
   </Target>
+
+  <ItemGroup>
+    <FilesToCopy Include="$(ProjectDir)\packages\libxml2.redist.2.7.8.7\build\native\bin\v110\Win32\Release\dynamic\cdecl\libxml2.dll"/>
+    <FilesToCopy Include="$(ProjectDir)\packages\libiconv.redist.1.14.0.11\build\native\bin\v110\Win32\Release\dynamic\cdecl\libiconv.dll"/>
+    <FilesToCopy Include="$(ProjectDir)\packages\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x86.1.0.2.0\lib\native\v140\windesktop\msvcstl\dyn\rt-dyn\x86\release\*.dll"/>
+    <FilesToCopy Include="$(ProjectDir)\packages\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\lib\native\v140\windesktop\msvcstl\dyn\rt-dyn\Win32\Release\zlib.dll"/>
+  </ItemGroup>
+
+  <Target Name="CopyFiles" AfterTargets="AfterBuild">
+    <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutDir)"/>
+  </Target>
 </Project>

--- a/msvc/ios-webkit-debug-proxy.vcxproj
+++ b/msvc/ios-webkit-debug-proxy.vcxproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\fix8.dependencies.getopt.1.0.20151130.1\build\native\fix8.dependencies.getopt.props" Condition="Exists('packages\fix8.dependencies.getopt.1.0.20151130.1\build\native\fix8.dependencies.getopt.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -17,6 +18,15 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\*.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\*.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{21DAC937-6A81-4ED6-8D04-388A81EF02C2}</ProjectGuid>
@@ -71,15 +81,19 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(ProjectDir)..\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(ProjectDir)..\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(ProjectDir)..\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(ProjectDir)..\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -87,7 +101,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -100,7 +114,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,7 +129,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -132,7 +146,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -141,18 +155,51 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <Text Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="stdafx.h" />
-    <ClInclude Include="targetver.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="ios-webkit-debug-proxy.cpp" />
-    <ClCompile Include="stdafx.cpp" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="packages\libimobiledevice.redist.1.2.0.40\build\native\libimobiledevice.redist.targets" Condition="Exists('packages\libimobiledevice.redist.1.2.0.40\build\native\libimobiledevice.redist.targets')" />
+    <Import Project="packages\libimobiledevice.1.2.0.40\build\native\libimobiledevice.targets" Condition="Exists('packages\libimobiledevice.1.2.0.40\build\native\libimobiledevice.targets')" />
+    <Import Project="packages\libiconv.redist.1.14.0.11\build\native\libiconv.redist.targets" Condition="Exists('packages\libiconv.redist.1.14.0.11\build\native\libiconv.redist.targets')" />
+    <Import Project="packages\libiconv.1.14.0.11\build\native\libiconv.targets" Condition="Exists('packages\libiconv.1.14.0.11\build\native\libiconv.targets')" />
+    <Import Project="packages\libplist.redist.1.12.49\build\native\libplist.redist.targets" Condition="Exists('packages\libplist.redist.1.12.49\build\native\libplist.redist.targets')" />
+    <Import Project="packages\libxml2.redist.2.7.8.7\build\native\libxml2.redist.targets" Condition="Exists('packages\libxml2.redist.2.7.8.7\build\native\libxml2.redist.targets')" />
+    <Import Project="packages\libxml2.2.7.8.7\build\native\libxml2.targets" Condition="Exists('packages\libxml2.2.7.8.7\build\native\libxml2.targets')" />
+    <Import Project="packages\libplist.1.12.49\build\native\libplist.targets" Condition="Exists('packages\libplist.1.12.49\build\native\libplist.targets')" />
+    <Import Project="packages\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.targets" Condition="Exists('packages\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.targets')" />
+    <Import Project="packages\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x64.1.0.2.0\build\native\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x64.targets" Condition="Exists('packages\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x64.1.0.2.0\build\native\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x64.targets')" />
+    <Import Project="packages\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x86.1.0.2.0\build\native\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x86.targets" Condition="Exists('packages\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x86.1.0.2.0\build\native\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x86.targets')" />
+    <Import Project="packages\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.targets" Condition="Exists('packages\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" />
+    <Import Project="packages\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x64.1.0.2.0\build\native\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x64.targets" Condition="Exists('packages\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x64.1.0.2.0\build\native\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x64.targets')" />
+    <Import Project="packages\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x86.1.0.2.0\build\native\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x86.targets" Condition="Exists('packages\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x86.1.0.2.0\build\native\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x86.targets')" />
+    <Import Project="packages\fix8.dependencies.getopt.1.0.20151130.1\build\native\fix8.dependencies.getopt.targets" Condition="Exists('packages\fix8.dependencies.getopt.1.0.20151130.1\build\native\fix8.dependencies.getopt.targets')" />
+    <Import Project="packages\bzip2.redist.1.0.6.7\build\native\bzip2.redist.targets" Condition="Exists('packages\bzip2.redist.1.0.6.7\build\native\bzip2.redist.targets')" />
+    <Import Project="packages\bzip2.1.0.6.7\build\native\bzip2.targets" Condition="Exists('packages\bzip2.1.0.6.7\build\native\bzip2.targets')" />
+    <Import Project="packages\pcre.redist.8.32.0.7\build\native\pcre.redist.targets" Condition="Exists('packages\pcre.redist.8.32.0.7\build\native\pcre.redist.targets')" />
+    <Import Project="packages\pcre.8.32.0.7\build\native\pcre.targets" Condition="Exists('packages\pcre.8.32.0.7\build\native\pcre.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\libimobiledevice.redist.1.2.0.40\build\native\libimobiledevice.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\libimobiledevice.redist.1.2.0.40\build\native\libimobiledevice.redist.targets'))" />
+    <Error Condition="!Exists('packages\libimobiledevice.1.2.0.40\build\native\libimobiledevice.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\libimobiledevice.1.2.0.40\build\native\libimobiledevice.targets'))" />
+    <Error Condition="!Exists('packages\libiconv.redist.1.14.0.11\build\native\libiconv.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\libiconv.redist.1.14.0.11\build\native\libiconv.redist.targets'))" />
+    <Error Condition="!Exists('packages\libiconv.1.14.0.11\build\native\libiconv.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\libiconv.1.14.0.11\build\native\libiconv.targets'))" />
+    <Error Condition="!Exists('packages\libplist.redist.1.12.49\build\native\libplist.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\libplist.redist.1.12.49\build\native\libplist.redist.targets'))" />
+    <Error Condition="!Exists('packages\libxml2.redist.2.7.8.7\build\native\libxml2.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\libxml2.redist.2.7.8.7\build\native\libxml2.redist.targets'))" />
+    <Error Condition="!Exists('packages\libxml2.2.7.8.7\build\native\libxml2.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\libxml2.2.7.8.7\build\native\libxml2.targets'))" />
+    <Error Condition="!Exists('packages\libplist.1.12.49\build\native\libplist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\libplist.1.12.49\build\native\libplist.targets'))" />
+    <Error Condition="!Exists('packages\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.targets'))" />
+    <Error Condition="!Exists('packages\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x64.1.0.2.0\build\native\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x64.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x64.1.0.2.0\build\native\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x64.targets'))" />
+    <Error Condition="!Exists('packages\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x86.1.0.2.0\build\native\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x86.1.0.2.0\build\native\openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x86.targets'))" />
+    <Error Condition="!Exists('packages\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.targets'))" />
+    <Error Condition="!Exists('packages\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x64.1.0.2.0\build\native\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x64.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x64.1.0.2.0\build\native\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x64.targets'))" />
+    <Error Condition="!Exists('packages\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x86.1.0.2.0\build\native\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x86.1.0.2.0\build\native\openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x86.targets'))" />
+    <Error Condition="!Exists('packages\fix8.dependencies.getopt.1.0.20151130.1\build\native\fix8.dependencies.getopt.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\fix8.dependencies.getopt.1.0.20151130.1\build\native\fix8.dependencies.getopt.props'))" />
+    <Error Condition="!Exists('packages\fix8.dependencies.getopt.1.0.20151130.1\build\native\fix8.dependencies.getopt.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\fix8.dependencies.getopt.1.0.20151130.1\build\native\fix8.dependencies.getopt.targets'))" />
+    <Error Condition="!Exists('packages\bzip2.redist.1.0.6.7\build\native\bzip2.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\bzip2.redist.1.0.6.7\build\native\bzip2.redist.targets'))" />
+    <Error Condition="!Exists('packages\bzip2.1.0.6.7\build\native\bzip2.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\bzip2.1.0.6.7\build\native\bzip2.targets'))" />
+    <Error Condition="!Exists('packages\pcre.redist.8.32.0.7\build\native\pcre.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\pcre.redist.8.32.0.7\build\native\pcre.redist.targets'))" />
+    <Error Condition="!Exists('packages\pcre.8.32.0.7\build\native\pcre.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\pcre.8.32.0.7\build\native\pcre.targets'))" />
+  </Target>
 </Project>

--- a/msvc/ios-webkit-debug-proxy.vcxproj
+++ b/msvc/ios-webkit-debug-proxy.vcxproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\*.h" />
+    <ClInclude Include="config.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -81,19 +82,19 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(ProjectDir)..\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\include;$(ProjectDir);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(ProjectDir)..\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\include;$(ProjectDir);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(ProjectDir)..\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\include;$(ProjectDir);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(ProjectDir)..\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\include;$(ProjectDir);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -101,7 +102,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;HAVE_CONFIG_H</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -114,7 +115,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;HAVE_CONFIG_H</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -129,7 +130,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;HAVE_CONFIG_H</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -146,7 +147,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;HAVE_CONFIG_H</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc/ios-webkit-debug-proxy.vcxproj
+++ b/msvc/ios-webkit-debug-proxy.vcxproj
@@ -107,6 +107,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -120,6 +121,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -130,13 +132,14 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;HAVE_CONFIG_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;HAVE_CONFIG_H;</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -154,6 +157,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ws2_32.lib;$(ProjectDir)packages\libxml2.2.7.8.7\build\native\lib\v110\Win32\Release\dynamic\cdecl\libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/msvc/packages.config
+++ b/msvc/packages.config
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="bzip2" version="1.0.6.7" targetFramework="native" />
+  <package id="bzip2.redist" version="1.0.6.7" targetFramework="native" />
+  <package id="fix8.dependencies.getopt" version="1.0.20151130.1" targetFramework="native" />
+  <package id="libiconv" version="1.14.0.11" targetFramework="native" />
+  <package id="libiconv.redist" version="1.14.0.11" targetFramework="native" />
+  <package id="libimobiledevice" version="1.2.0.40" targetFramework="native" />
+  <package id="libimobiledevice.redist" version="1.2.0.40" targetFramework="native" />
+  <package id="libplist" version="1.12.49" targetFramework="native" />
+  <package id="libplist.redist" version="1.12.49" targetFramework="native" />
+  <package id="libxml2" version="2.7.8.7" targetFramework="native" />
+  <package id="libxml2.redist" version="2.7.8.7" targetFramework="native" />
+  <package id="openssl" version="1.0.2.0" targetFramework="native" />
+  <package id="openssl.v120.windesktop.msvcstl.dyn.rt-dyn" version="1.0.2.0" targetFramework="native" />
+  <package id="openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x64" version="1.0.2.0" targetFramework="native" />
+  <package id="openssl.v120.windesktop.msvcstl.dyn.rt-dyn.x86" version="1.0.2.0" targetFramework="native" />
+  <package id="openssl.v140.windesktop.msvcstl.dyn.rt-dyn" version="1.0.2.0" targetFramework="native" />
+  <package id="openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x64" version="1.0.2.0" targetFramework="native" />
+  <package id="openssl.v140.windesktop.msvcstl.dyn.rt-dyn.x86" version="1.0.2.0" targetFramework="native" />
+  <package id="pcre" version="8.32.0.7" targetFramework="native" />
+  <package id="pcre.redist" version="8.32.0.7" targetFramework="native" />
+  <package id="zlib.v120.windesktop.msvcstl.dyn.rt-dyn" version="1.2.8.8" targetFramework="native" />
+  <package id="zlib.v140.windesktop.msvcstl.dyn.rt-dyn" version="1.2.8.8" targetFramework="native" />
+</packages>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,8 +3,8 @@
 
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
-AM_CFLAGS = $(GLOBAL_CFLAGS) $(libimobiledevice_CFLAGS) $(libplist_CFLAGS)
-AM_LDFLAGS = $(libimobiledevice_LIBS) $(libplist_LIBS)
+AM_CFLAGS = $(GLOBAL_CFLAGS) $(libimobiledevice_CFLAGS) $(libplist_CFLAGS) $(libpcreposix_CFLAGS)
+AM_LDFLAGS = $(libimobiledevice_LIBS) $(libplist_LIBS) $(libpcreposix_LIBS)
 
 lib_LTLIBRARIES = libios_webkit_debug_proxy.la
 libios_webkit_debug_proxy_la_LIBADD =
@@ -37,5 +37,6 @@ ios_webkit_debug_proxy_SOURCES = ios_webkit_debug_proxy_main.c \
     validate_utf8.h \
     webinspector.c webinspector.h \
     websocket.c websocket.h
+ios_webkit_debug_proxy_LDADD =
 ios_webkit_debug_proxy_CFLAGS = $(AM_CFLAGS)
 ios_webkit_debug_proxy_LDFLAGS = $(AM_LDFLAGS)

--- a/src/char_buffer.c
+++ b/src/char_buffer.c
@@ -1,6 +1,10 @@
 // Google BSD license http://code.google.com/google_bsd_license.html
 // Copyright 2012 Google Inc. wrightt@google.com
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/device_listener.c
+++ b/src/device_listener.c
@@ -14,8 +14,8 @@
 #include <stdlib.h>
 #include <string.h>
 #ifdef WIN32
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 static int wsa_init = 0;
 #else
 #include <resolv.h>

--- a/src/device_listener.c
+++ b/src/device_listener.c
@@ -24,7 +24,9 @@ static int wsa_init = 0;
 #include <sys/stat.h>
 #include <sys/un.h>
 #endif
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <plist/plist.h>
 

--- a/src/device_listener.c
+++ b/src/device_listener.c
@@ -1,23 +1,34 @@
 // Google BSD license http://code.google.com/google_bsd_license.html
 // Copyright 2012 Google Inc. wrightt@google.com
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #define _GNU_SOURCE
 #include <errno.h>
 #include <getopt.h>
 #include <math.h>
-#include <resolv.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef WIN32
+#include <windows.h>
+#include <winsock2.h>
+static int wsa_init = 0;
+#else
+#include <resolv.h>
 #include <sys/fcntl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
+#endif
 #include <unistd.h>
 
 #include <plist/plist.h>
 
+#include "stpncpy.h"
 #include "char_buffer.h"
 #include "hash_table.h"
 #include "device_listener.h"
@@ -31,6 +42,7 @@
 //
 
 #define USBMUXD_FILE_PATH "/var/run/usbmuxd"
+#define USBMUXD_PORT 27015
 #define TYPE_PLIST 8
 
 struct dl_private {
@@ -41,8 +53,9 @@ struct dl_private {
 };
 
 int dl_connect(int recv_timeout) {
-  const char *filename = USBMUXD_FILE_PATH;
   int fd = -1;
+#ifndef WIN32
+  const char *filename = USBMUXD_FILE_PATH;
   struct stat fst;
   if (stat(filename, &fst) ||
       !S_ISSOCK(fst.st_mode) ||
@@ -65,7 +78,51 @@ int dl_connect(int recv_timeout) {
     if (!opts || fcntl(fd, F_SETFL, (opts | O_NONBLOCK)) < 0) {
       perror("Could not set socket to non-blocking");
     }
-  } else {
+  }
+#else
+  const char *addr = "127.0.0.1";
+
+  WSADATA wsa_data;
+  if (!wsa_init) {
+    if (WSAStartup(MAKEWORD(2,2), &wsa_data) != ERROR_SUCCESS) {
+      fprintf(stderr, "WSAStartup failed!\n");
+      ExitProcess(-1);
+    }
+    wsa_init = 1;
+  }
+
+  struct hostent *hp;
+  struct sockaddr_in saddr;
+
+  hp = gethostbyname(addr);
+  fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+  int optval = 1;
+  if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char *)&optval, sizeof(int)) != 0) {
+    perror("setsockopt() failed");
+    closesocket(fd);
+    return -1;
+  }
+
+  memset((void *) &saddr, 0, sizeof(saddr));
+  saddr.sin_family = AF_INET;
+  saddr.sin_addr.s_addr = *(uint32_t *) hp->h_addr;
+  saddr.sin_port = htons(USBMUXD_PORT);
+
+  if (connect(fd, (struct sockaddr *) &saddr, sizeof(saddr)) != 0) {
+    perror("Socket connect failed");
+    closesocket(fd);
+    return -2;
+  }
+
+  u_long iMode = 1;
+  if (recv_timeout < 0) {
+    if (ioctlsocket(fd, FIONBIO, &iMode) != 0) {
+      perror("Could not set socket to non-blocking");
+    }
+  }
+#endif
+  else {
     long millis = (recv_timeout > 0 ? recv_timeout : 5000);
     struct timeval tv;
     tv.tv_sec = (time_t) (millis / 1000);

--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -14,9 +14,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <sys/fcntl.h>
-#include <sys/stat.h>
 #include <unistd.h>
+#else
+#include <fcntl.h>
+#endif
+#include <sys/stat.h>
 
 #include "asprintf.h"
 #include "stpcpy.h"

--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -1,9 +1,9 @@
 // Google BSD license http://code.google.com/google_bsd_license.html
 // Copyright 2012 Google Inc. wrightt@google.com
 
-//
-//
-//
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
 
 #define _GNU_SOURCE
 #include <errno.h>
@@ -18,6 +18,9 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "asprintf.h"
+#include "stpcpy.h"
+#include "strndup.h"
 #include "char_buffer.h"
 #include "device_listener.h"
 #include "hash_table.h"

--- a/src/ios_webkit_debug_proxy_main.c
+++ b/src/ios_webkit_debug_proxy_main.c
@@ -5,16 +5,27 @@
 // This "main" connects the debugger to our socket management backend.
 //
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #define _GNU_SOURCE
 #include <getopt.h>
 #include <errno.h>
-#include <regex.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef HAVE_REGEX_H
+#include <pcre.h>
+#include <pcreposix.h>
+#else
+#include <regex.h>
+#endif
+
+#include "asprintf.h"
 #include "device_listener.h"
 #include "hash_table.h"
 #include "ios_webkit_debug_proxy.h"

--- a/src/ios_webkit_debug_proxy_main.c
+++ b/src/ios_webkit_debug_proxy_main.c
@@ -19,7 +19,9 @@
 #include <string.h>
 
 #ifndef HAVE_REGEX_H
+#ifndef _MSC_VER
 #include <pcre.h>
+#endif
 #include <pcreposix.h>
 #else
 #include <regex.h>

--- a/src/port_config.c
+++ b/src/port_config.c
@@ -10,7 +10,9 @@
 #include <string.h>
 
 #ifndef HAVE_REGEX_H
+#ifndef _MSC_VER
 #include <pcre.h>
+#endif
 #include <pcreposix.h>
 #else
 #include <regex.h>

--- a/src/port_config.c
+++ b/src/port_config.c
@@ -1,15 +1,23 @@
 // Google BSD license http://code.google.com/google_bsd_license.html
 // Copyright 2012 Google Inc. wrightt@google.com
 
-//
-//
-//
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
 
-#include <regex.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef HAVE_REGEX_H
+#include <pcre.h>
+#include <pcreposix.h>
+#else
+#include <regex.h>
+#endif
+
+#include "strndup.h"
+#include "getline.h"
 #include "port_config.h"
 
 

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -1,6 +1,10 @@
 // Google BSD license http://code.google.com/google_bsd_license.html
 // Copyright 2014 Google Inc. wrightt@google.com
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #define _GNU_SOURCE
 #include <errno.h>
 #include <getopt.h>
@@ -16,6 +20,7 @@
 #include <uuid/uuid.h>
 #endif
 
+#include "asprintf.h"
 #include "rpc.h"
 
 

--- a/src/socket_manager.c
+++ b/src/socket_manager.c
@@ -1,6 +1,10 @@
 // Google BSD license http://code.google.com/google_bsd_license.html
 // Copyright 2012 Google Inc. wrightt@google.com
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #define _GNU_SOURCE
 #include <errno.h>
 #include <stdarg.h>
@@ -9,19 +13,30 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef WIN32
+#ifndef WINVER
+#define WINVER 0x0501
+#endif
+#include <windows.h>
+#include <winsock2.h>
+static int wsa_init = 0;
+#include <ws2tcpip.h>
+#else
 #include <netdb.h>
 #include <netinet/in.h>
 #include <sys/fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#endif
 #include <sys/time.h>
 #include <unistd.h>
 
+#include "asprintf.h"
 #include "char_buffer.h"
 #include "socket_manager.h"
 #include "hash_table.h"
 
-#ifdef __MACH__
+#if defined(__MACH__) || defined(WIN32)
 #define SIZEOF_FD_SET sizeof(struct fd_set)
 #define RECV_FLAGS 0
 #else
@@ -69,29 +84,57 @@ void sm_sendq_free(sm_sendq_t sendq);
 
 
 int sm_listen(int port) {
+#ifdef WIN32
+  WSADATA wsa_data;
+  if (!wsa_init) {
+    if (WSAStartup(MAKEWORD(2,2), &wsa_data) != ERROR_SUCCESS) {
+      fprintf(stderr, "WSAStartup failed!\n");
+      ExitProcess(-1);
+    }
+    wsa_init = 1;
+  }
+#endif
   int fd = socket(AF_INET, SOCK_STREAM, 0);
   if (fd < 0) {
     return -1;
   }
-  int opts = fcntl(fd, F_GETFL);
+
   struct sockaddr_in local;
   local.sin_family = AF_INET;
   local.sin_addr.s_addr = INADDR_ANY;
   local.sin_port = htons(port);
   int ra = 1;
-  int nb = 1;
+  u_long nb = 1;
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char *)&ra,sizeof(ra)) < 0 ||
-      opts < 0 ||
+#ifndef WIN32
+      fcntl(fd, F_GETFL) < 0 ||
       ioctl(fd, FIONBIO, (char *)&nb) < 0 ||
+#else
+      ioctlsocket(fd, FIONBIO, &nb) != 0 ||
+#endif
       bind(fd, (struct sockaddr*)&local, sizeof(local)) < 0 ||
       listen(fd, 5)) {
+#ifndef WIN32
     close(fd);
+#else
+    closesocket(fd);
+#endif
     return -1;
   }
   return fd;
 }
 
 int sm_connect(const char *hostname, int port) {
+#ifdef WIN32
+  WSADATA wsa_data;
+  if (!wsa_init) {
+    if (WSAStartup(MAKEWORD(2,2), &wsa_data) != ERROR_SUCCESS) {
+      fprintf(stderr, "WSAStartup failed!\n");
+      ExitProcess(-1);
+    }
+    wsa_init = 1;
+  }
+#endif
   struct addrinfo hints;
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = PF_UNSPEC;
@@ -112,13 +155,18 @@ int sm_connect(const char *hostname, int port) {
   struct addrinfo *res;
   for (res = res0; res; res = res->ai_next) {
     if (fd > 0) {
+#ifndef WIN32
       close(fd);
+#else
+      closesocket(fd);
+#endif
     }
     fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
     if (fd < 0) {
       continue;
     }
     // try non-blocking connect, usually succeeds even if unreachable
+#ifndef WIN32
     int opts = fcntl(fd, F_GETFL);
     if (opts < 0 ||
         fcntl(fd, F_SETFL, (opts | O_NONBLOCK)) < 0 ||
@@ -126,6 +174,14 @@ int sm_connect(const char *hostname, int port) {
          (errno != EINPROGRESS))) {
       continue;
     }
+#else
+    u_long iMode = 1;
+    if (ioctlsocket(fd, FIONBIO, &iMode) != 0 ||
+        ((connect(fd, res->ai_addr, res->ai_addrlen) == INVALID_SOCKET) ==
+         (WSAGetLastError() != WSAEINPROGRESS))) {
+      continue;
+    }
+#endif
     // try blocking select to verify its reachable
     struct timeval to;
     to.tv_sec = 0;
@@ -133,22 +189,40 @@ int sm_connect(const char *hostname, int port) {
     fd_set error_fds;
     FD_ZERO(&error_fds);
     FD_SET(fd, &error_fds);
+#ifndef WIN32
     if (fcntl(fd, F_SETFL, opts) < 0) {
       continue;
     }
+#else
+    iMode = 0;
+    if(ioctlsocket(fd, FIONBIO, &iMode) != 0) {
+      continue;
+    }
+#endif
     int is_error = select(fd + 1, &error_fds, NULL, NULL, &to);
     if (is_error) {
       continue;
     }
     // success!  set back to non-blocking and return
+#ifndef WIN32
     if (fcntl(fd, F_SETFL, (opts | O_NONBLOCK)) < 0) {
       continue;
     }
+#else
+    iMode = 1;
+    if(ioctlsocket(fd, FIONBIO, &iMode) != 0) {
+      continue;
+    }
+#endif
     ret = fd;
     break;
   }
   if (fd > 0 && ret <= 0) {
+#ifndef WIN32
     close(fd);
+#else
+    closesocket(fd);
+#endif
   }
   freeaddrinfo(res0);
   return ret;
@@ -201,7 +275,11 @@ sm_status sm_remove_fd(sm_t self, int fd) {
   bool is_server = FD_ISSET(fd, my->server_fds);
   sm_on_debug(self, "ss.remove%s_fd(%d)", (is_server ? "_server" : ""), fd);
   sm_status ret = self->on_close(self, fd, value, is_server);
+#ifndef WIN32
   close(fd);
+#else
+  closesocket(fd);
+#endif
   FD_CLR(fd, my->all_fds);
   if (is_server) {
     FD_CLR(fd, my->server_fds);
@@ -245,7 +323,11 @@ sm_status sm_send(sm_t self, int fd, const char *data, size_t length,
     while (1) {
       ssize_t sent_bytes = send(fd, (void*)head, (tail - head), 0);
       if (sent_bytes <= 0) {
+#ifndef WIN32
         if (sent_bytes && errno != EWOULDBLOCK) {
+#else
+        if (sent_bytes && WSAGetLastError() != WSAEWOULDBLOCK) {
+#endif
           sm_on_debug(self, "ss.failed fd=%d", fd);
           perror("send failed");
           return SM_ERROR;
@@ -290,7 +372,11 @@ void sm_accept(sm_t self, int fd) {
   while (1) {
     int new_fd = accept(fd, NULL, NULL);
     if (new_fd < 0) {
+#ifdef WIN32
+      if(WSAGetLastError() != WSAEWOULDBLOCK) {
+#else
       if (errno != EWOULDBLOCK) {
+#endif
         perror("accept failed");
         self->remove_fd(self, fd);
         return;
@@ -302,10 +388,18 @@ void sm_accept(sm_t self, int fd) {
     void *value = ht_get_value(my->fd_to_value, HT_KEY(fd));
     void *new_value = NULL;
     if (self->on_accept(self, fd, value, new_fd, &new_value)) {
+#ifndef WIN32
       close(new_fd);
+#else
+      closesocket(new_fd);
+#endif
     } else if (self->add_fd(self, new_fd, new_value, false)) {
       self->on_close(self, new_fd, new_value, false);
+#ifndef WIN32
       close(new_fd);
+#else
+      closesocket(new_fd);
+#endif
     }
   }
 }
@@ -322,7 +416,11 @@ void sm_resend(sm_t self, int fd) {
     while (head < tail) {
       ssize_t sent_bytes = send(fd, (void*)head, (tail - head), 0);
       if (sent_bytes <= 0) {
+#ifndef WIN32
         if (sent_bytes && errno != EWOULDBLOCK) {
+#else
+        if (sent_bytes && WSAGetLastError() != WSAEWOULDBLOCK) {
+#endif
           perror("sendq retry failed");
           self->remove_fd(self, fd);
           return;
@@ -377,7 +475,11 @@ void sm_recv(sm_t self, int fd) {
   while (1) {
     ssize_t read_bytes = recv(fd, my->tmp_buf, my->tmp_buf_length, RECV_FLAGS);
     if (read_bytes < 0) {
+#ifndef WIN32
       if (errno != EWOULDBLOCK) {
+#else
+      if (WSAGetLastError() != WSAEWOULDBLOCK) {
+#endif
         perror("recv failed");
         self->remove_fd(self, fd);
       }
@@ -415,10 +517,18 @@ int sm_select(sm_t self, int timeout_secs) {
     return 0; // timeout, select again
   }
   if (num_ready < 0) {
+#ifndef WIN32
     if (errno != EINTR && errno != EAGAIN) {
+#else
+    if (WSAGetLastError() != WSAEINTR && WSAGetLastError() != WSAEINPROGRESS) {
+#endif
       // might want to sleep here?
       perror("select failed");
+#ifndef WIN32
       return -errno;
+#else
+      return -WSAGetLastError();
+#endif
     }
     return 0;
   }

--- a/src/socket_manager.c
+++ b/src/socket_manager.c
@@ -28,8 +28,10 @@ static int wsa_init = 0;
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #endif
+#ifndef _MSC_VER
 #include <sys/time.h>
 #include <unistd.h>
+#endif
 
 #include "asprintf.h"
 #include "char_buffer.h"

--- a/src/socket_manager.c
+++ b/src/socket_manager.c
@@ -17,8 +17,8 @@
 #ifndef WINVER
 #define WINVER 0x0501
 #endif
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 static int wsa_init = 0;
 #include <ws2tcpip.h>
 #else

--- a/src/webinspector.c
+++ b/src/webinspector.c
@@ -1,6 +1,10 @@
 // Google BSD license http://code.google.com/google_bsd_license.html
 // Copyright 2012 Google Inc. wrightt@google.com
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #define _GNU_SOURCE
 #include <errno.h>
 #include <getopt.h>
@@ -10,8 +14,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef WIN32
+#include <winsock2.h>
+#include <windows.h>
+#else
 #include <sys/fcntl.h>
 #include <sys/socket.h>
+#endif
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -19,6 +28,7 @@
 #include <libimobiledevice/libimobiledevice.h>
 #include <libimobiledevice/lockdown.h>
 
+#include "asprintf.h"
 #include "char_buffer.h"
 #include "webinspector.h"
 
@@ -69,11 +79,13 @@ wi_status idevice_connection_get_fd(idevice_connection_t connection,
     return WI_ERROR;
   }
   int fd = (int)(long)c->data;
+#ifndef WIN32
   struct stat fd_stat;
   if (fstat(fd, &fd_stat) < 0 || !S_ISSOCK(fd_stat.st_mode)) {
     perror("idevice_connection fd is not a socket?");
     return WI_ERROR;
   }
+#endif
   *to_fd = fd;
   return WI_SUCCESS;
 }
@@ -140,8 +152,13 @@ int wi_connect(const char *device_id, char **to_device_id,
   }
 
   if (recv_timeout < 0) {
+#ifndef WIN32
     int opts = fcntl(fd, F_GETFL);
     if (!opts || fcntl(fd, F_SETFL, (opts | O_NONBLOCK)) < 0) {
+#else
+    u_long iMode = 1;
+    if (ioctlsocket(fd, FIONBIO, &iMode) != 0) {
+#endif
       perror("Could not set socket to non-blocking");
       goto leave_cleanup;
     }
@@ -162,7 +179,11 @@ int wi_connect(const char *device_id, char **to_device_id,
 
 leave_cleanup:
   if (ret < 0 && fd > 0) {
+#ifndef WIN32
     close(fd);
+#else
+    closesocket(fd);
+#endif
   }
   // don't call usbmuxd_disconnect(fd)!
   //idevice_disconnect(connection);

--- a/src/webinspector.c
+++ b/src/webinspector.c
@@ -22,7 +22,9 @@
 #include <sys/socket.h>
 #endif
 #include <sys/stat.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <libimobiledevice/installation_proxy.h>
 #include <libimobiledevice/libimobiledevice.h>

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -1,6 +1,10 @@
 // Google BSD license http://code.google.com/google_bsd_license.html
 // Copyright 2012 Google Inc. wrightt@google.com
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #define _GNU_SOURCE
 #include <stdarg.h>
 #include <stdbool.h>
@@ -8,6 +12,29 @@
 #include <stdlib.h>
 #include <time.h>
 
+#ifdef WIN32
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+#ifndef HAVE_HTOBE64
+#ifdef WORDS_BIGENDIAN
+#define htobe64(x) (x)
+#else
+#define htobe64(x) ((((x) & 0xFF00000000000000ull) >> 56) \
+                  | (((x) & 0x00FF000000000000ull) >> 40) \
+                  | (((x) & 0x0000FF0000000000ull) >> 24) \
+                  | (((x) & 0x000000FF00000000ull) >> 8) \
+                  | (((x) & 0x00000000FF000000ull) << 8) \
+                  | (((x) & 0x0000000000FF0000ull) << 24) \
+                  | (((x) & 0x000000000000FF00ull) << 40) \
+                  | (((x) & 0x00000000000000FFull) << 56))
+#endif
+#endif
+
+#include "strndup.h"
+#include "strcasestr.h"
 #include "websocket.h"
 #include "char_buffer.h"
 
@@ -15,19 +42,6 @@
 #include "sha1.h"
 
 #include "validate_utf8.h"
-
-#ifndef htobe64
-#ifdef __APPLE__
-#include <libkern/OSByteOrder.h>
-#define htobe64(h) OSSwapHostToBigInt64(h)
-#elif _MSC_VER
-#define htobe64(h) _byteswap_uint64(h)
-#endif
-#endif
-
-#ifndef htons
-#include <arpa/inet.h>
-#endif
 
 typedef int8_t ws_state;
 #define STATE_ERROR 1


### PR DESCRIPTION
This PR builds on @artygus 's `mingw32` branch and adds native support for building using Visual Studio 2015.

The Visual Studio build relies on NuGet packages (amongst others, the NuGet packages for libplist and libimobiledevice we maintain) to pull in the dependencies. This keeps the changes to the ios-webkit-debug-proxy repository to a minimum.

This PR is based on the `mingw32` branch but cherry-picks commit a3de70e (which contains the win32 compatibility changes), and excludes the other mingw-only changes.

In short, the changes boil down to:
- A new Visual Studio solution & project, which supports building with Visual Studio 2015
- A `config.h` file, which contains the various "glue" `#defines`
- Some `#include` updates, such as the reordering of the `#include` of `windows.h` and `winsock2.h` and `#ifdef _MSC_VER` statements.
- An AppVeyor build script which provides for continuous integration builds.

With this build, I can F5 (run & debug) the project. http://localhost:9221/json shows the devices connected and, say, http://localhost:9222/json shows the current Safari sessions on the corresponding device. 

There's one remaining issue with the `free` statements in src/webinspector.c:192 that I need to look into; other than that, all looks good.

Happy to squash commits, rewrite history & make other changes if that helps getting this PR merged into the main branch.
