### PR TITLE
Fix "Unknown app_id" issue by resend "forwardGetListing"

### DIFF
--- a/include/rpc.h
+++ b/include/rpc.h
@@ -27,9 +27,13 @@ rpc_status rpc_new_uuid(char **to_uuid);
 struct rpc_app_struct {
   char *app_id;
   char *app_name;
+  char *host_id;
   bool is_proxy;
 };
 typedef struct rpc_app_struct *rpc_app_t;
+rpc_app_t rpc_new_app();
+void rpc_free_app(rpc_app_t app);
+rpc_status rpc_copy_app(rpc_app_t app, rpc_app_t *to_app);
 
 struct rpc_page_struct {
   uint32_t page_id;

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -538,6 +538,7 @@ void rpc_free(rpc_t self) {
     free(self);
   }
 }
+
 rpc_t rpc_new() {
   rpc_t self = (rpc_t)malloc(sizeof(struct rpc_struct));
   if (!self) {
@@ -563,6 +564,7 @@ rpc_app_t rpc_new_app() {
   }
   return app;
 }
+
 void rpc_free_app(rpc_app_t app) {
   if (app) {
     free(app->app_id);
@@ -571,6 +573,20 @@ void rpc_free_app(rpc_app_t app) {
     free(app);
   }
 }
+
+rpc_status rpc_copy_app(rpc_app_t app, rpc_app_t *to_app) {
+  rpc_app_t new_app = (to_app ? rpc_new_app() : NULL);
+  if (!new_app) {
+    return RPC_ERROR;
+  }
+
+  new_app->app_id = strdup(app->app_id);
+  new_app->app_name = strdup(app->app_name);
+  new_app->is_proxy = app->is_proxy;
+  *to_app = new_app;
+  return RPC_SUCCESS;
+}
+
 rpc_status rpc_parse_app(const plist_t node, rpc_app_t *to_app) {
   rpc_app_t app = (to_app ? rpc_new_app() : NULL);
   if (!app ||
@@ -590,7 +606,6 @@ rpc_status rpc_parse_app(const plist_t node, rpc_app_t *to_app) {
   return RPC_SUCCESS;
 }
 
-
 void rpc_free_apps(rpc_app_t *apps) {
   if (apps) {
     rpc_app_t *a = apps;
@@ -600,6 +615,7 @@ void rpc_free_apps(rpc_app_t *apps) {
     free(apps);
   }
 }
+
 rpc_status rpc_parse_apps(const plist_t node, rpc_app_t **to_apps) {
   if (!to_apps) {
     return RPC_ERROR;


### PR DESCRIPTION
I fixed "Unknown app_id" issue by 

Keep the app_id of "Safari"
Resend "forwardGetListing" with app_id of "Safari" if we meet "Unknown app_id"
I tested with 6 iOS devices (from 9.0.1 to 9.3.4) run in parallel with Appium 