### PR TITLE
Changed charset to UTF-8 for device and page selection HTML

### DIFF
--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -212,7 +212,7 @@ char *iwdp_ipages_to_text(iwdp_ipage_t *ipages, bool want_json,
 const char *EXT_TO_MIME[][2] = {
   {"css", "text/css"},
   {"gif", "image/gif; charset=binary"},
-  {"html", "text/html; charset=ISO-8859-1"},
+  {"html", "text/html; charset=UTF-8"},
   {"ico", "image/x-icon"},
   {"js", "application/javascript"},
   {"json", "application/json"},

--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -215,7 +215,7 @@ const char *EXT_TO_MIME[][2] = {
   {"html", "text/html; charset=UTF-8"},
   {"ico", "image/x-icon"},
   {"js", "application/javascript"},
-  {"json", "application/json"},
+  {"json", "application/json; charset=UTF-8"},
   {"png", "image/png; charset=binary"},
   {"txt", "text/plain"},
 };


### PR DESCRIPTION
fixes #26

Does not appear to negatively affect any pages returned by the proxy.

(rebased reboot of #27, on @artygus’ request therein)