### PR TITLE
Do not remove app id when app update event occurs

### DIFF
--- a/src/ios_webkit_debug_proxy.c
+++ b/src/ios_webkit_debug_proxy.c
@@ -1420,11 +1420,6 @@ rpc_status iwdp_on_applicationSentData(rpc_t rpc,
 
 rpc_status iwdp_on_applicationUpdated(rpc_t rpc,
     const char *app_id, const char *dest_id) {
-  rpc_status result = iwdp_remove_app_id(rpc, app_id);
-  if (result) {
-    // Error removing app_id
-    return result;
-  }
   return iwdp_add_app_id(rpc, dest_id);
 }
 


### PR DESCRIPTION
There is no need to remove the app id from the hash when a `_rpc_applicationUpdated:` event occurs. This does not matter for iOS < 12.2, but on 12.2 we never get another `_rpc_applicationSentListing:` event to repopulate the available pages.

All the apps continue get cleaned up when the page disappears.

I've tested this with 10.3.3 and 12.2 (the only devices I have immediately on hand).