### PR TITLE
docs: update troubleshooting instructions re: brew reinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,8 @@ or
 Please upgrade libimobiledevice to version from master and rebuild ios-webkit-debug-proxy. Upcoming 1.2.1 has many fixes but not marked for release just yet. If you're on OS X:
 
     brew update
-    brew uninstall ios-webkit-debug-proxy
-    brew uninstall libimobiledevice
-    brew uninstall usbmuxd
+    brew unlink libimobiledevice ios-webkit-debug-proxy usbmuxd
+    brew uninstall --force libimobiledevice ios-webkit-debug-proxy usbmuxd
     brew install --HEAD usbmuxd
     brew install --HEAD libimobiledevice
     brew install -s ios-webkit-debug-proxy

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ or
 Please upgrade libimobiledevice to version from master and rebuild ios-webkit-debug-proxy. Upcoming 1.2.1 has many fixes but not marked for release just yet. If you're on OS X:
 
     brew update
-    brew unlink libimobiledevice ios-webkit-debug-proxy usbmuxd
     brew uninstall --force libimobiledevice ios-webkit-debug-proxy usbmuxd
     brew install --HEAD usbmuxd
     brew install --HEAD libimobiledevice

--- a/README.md
+++ b/README.md
@@ -190,9 +190,12 @@ or
 Please upgrade libimobiledevice to version from master and rebuild ios-webkit-debug-proxy. Upcoming 1.2.1 has many fixes but not marked for release just yet. If you're on OS X:
 
     brew update
-    brew reinstall --HEAD usbmuxd
-    brew reinstall --HEAD libimobiledevice
-    brew reinstall -s ios-webkit-debug-proxy
+    brew uninstall ios-webkit-debug-proxy
+    brew uninstall libimobiledevice
+    brew uninstall usbmuxd
+    brew install --HEAD usbmuxd
+    brew install --HEAD libimobiledevice
+    brew install -s ios-webkit-debug-proxy
 
 ##### Can not see Simulator
 


### PR DESCRIPTION
Homebrew doesn't allow users to change installation options with the `reinstall` command; running something like `brew reinstall --HEAD usbmuxd` will result in `Error: invalid option: --HEAD` (see https://github.com/Homebrew/brew/issues/5327).