### PR TITLE
ios 13 support changes - Perfecto contribution

### DIFF
--- a/include/ios-webkit-debug-proxy/socket_manager.h
+++ b/include/ios-webkit-debug-proxy/socket_manager.h
@@ -15,17 +15,28 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 
+#include <libimobiledevice/libimobiledevice.h>
+#include <libimobiledevice/service.h>
+	
 // Bind a server port, return the file descriptor (or -1 for error).
 int sm_listen(int port);
 
 // Connect to a server, return the file descriptor (or -1 for error).
 int sm_connect(const char *socket_addr);
-
-
+    
 typedef uint8_t sm_status;
 #define SM_ERROR 1
 #define SM_SUCCESS 0
 
+#define SSL_ERROR_NONE				0
+#define SSL_ERROR_SSL				1
+#define SSL_ERROR_WANT_READ			2
+#define SSL_ERROR_WANT_WRITE		3
+#define SSL_ERROR_WANT_X509_LOOKUP	4
+#define SSL_ERROR_SYSCALL			5 /* look at error stack/return value/errno */
+#define SSL_ERROR_ZERO_RETURN		6
+#define SSL_ERROR_WANT_CONNECT		7
+#define SSL_ERROR_WANT_ACCEPT		8
 
 struct sm_private;
 typedef struct sm_private *sm_private_t;
@@ -75,6 +86,24 @@ struct sm_struct {
   // For internal use only:
   sm_private_t private_state;
 };
+
+
+// based on libimobiledevice/src/idevice.h
+struct service_client_private 
+{
+ 	idevice_connection_t connection;
+};	
+enum connection_type {
+	CONNECTION_USBMUXD = 1
+};
+struct idevice_connection_private {
+	char *udid;  // added in v1.1.6
+	enum connection_type type;
+	void *data;
+	void *ssl_data;
+};
+
+
 
 #ifdef	__cplusplus
 }

--- a/src/char_buffer.c
+++ b/src/char_buffer.c
@@ -14,6 +14,10 @@
 
 #define MIN_LENGTH 1024
 
+// place holder ....
+void* connectionSSL = NULL;
+
+
 cb_t cb_new() {
   cb_t self = (cb_t)malloc(sizeof(struct cb_struct));
   if (self) {

--- a/src/char_buffer.c
+++ b/src/char_buffer.c
@@ -12,11 +12,9 @@
 
 #include "char_buffer.h"
 
-#define MIN_LENGTH 1024
-
-// place holder ....
 void* connectionSSL = NULL;
 
+#define MIN_LENGTH 1024
 
 cb_t cb_new() {
   cb_t self = (cb_t)malloc(sizeof(struct cb_struct));

--- a/src/ios_webkit_debug_proxy_main.c
+++ b/src/ios_webkit_debug_proxy_main.c
@@ -66,6 +66,7 @@ int main(int argc, char** argv) {
   signal(SIGINT, on_signal);
   signal(SIGTERM, on_signal);
 
+
 #ifdef WIN32
   WSADATA wsa_data;
   int res = WSAStartup(MAKEWORD(2,2), &wsa_data);

--- a/src/socket_manager.c
+++ b/src/socket_manager.c
@@ -27,13 +27,8 @@
 #include <sys/stat.h>
 #include <sys/un.h>
 #include <pthread.h>
-#endif
-
-
-#include <libimobiledevice/libimobiledevice.h>
-#include <libimobiledevice/service.h>
 #include <time.h>
-
+#endif
 
 #include "char_buffer.h"
 #include "socket_manager.h"
@@ -48,32 +43,8 @@
 #define RECV_FLAGS MSG_DONTWAIT
 #endif
 
-// SSL based communication types import 
-#define SSL_ERROR_NONE				0
-#define SSL_ERROR_SSL				1
-#define SSL_ERROR_WANT_READ			2
-#define SSL_ERROR_WANT_WRITE		3
-#define SSL_ERROR_WANT_X509_LOOKUP	4
-#define SSL_ERROR_SYSCALL			5 /* look at error stack/return value/errno */
-#define SSL_ERROR_ZERO_RETURN		6
-#define SSL_ERROR_WANT_CONNECT		7
-#define SSL_ERROR_WANT_ACCEPT		8
-
-enum connection_type {
-	CONNECTION_USBMUXD = 1
-};
-
-struct idevice_connection_private {
-	char *udid;  // added in v1.1.6
-	enum connection_type type;
-	void *data;
-	void *ssl_data;
-};
-
 extern idevice_connection_t connectionSSL;
 #define IS_SSL_FD(fd) if(connectionSSL!=NULL && (fd == (int)(long)connectionSSL->data))
-
-// SSL based communication types import 
 
 struct sm_private {
   struct timeval timeout;
@@ -580,42 +551,26 @@ void sm_resend(sm_t self, int fd) {
     sendq = nextq;
   }
 }
-
-
-void sm_recv_SSL(sm_t self,int fd)
-{
-	sm_private_t my = self->private_state;
-	while (1)
-	{
-		ssize_t read_bytes = 0;
-		idevice_error_t error = idevice_connection_receive(connectionSSL, my->tmp_buf, my->tmp_buf_length, (uint32_t*)&read_bytes);
-		if (error != IDEVICE_E_SUCCESS)
-			break;
-		
-		void *value = ht_get_value(my->fd_to_value, HT_KEY(fd));
-		if (read_bytes == 0 || self->on_recv(self, fd, value, my->tmp_buf, read_bytes))
-			break;
-	}
-
-	my->curr_recv_fd = 0;
-}
-
  
 void sm_recv(sm_t self, int fd) 
 {
-	
-	IS_SSL_FD(fd)
-	{
-		return sm_recv_SSL(self,fd);
+    sm_private_t my = self->private_state;
+    my->curr_recv_fd = fd;
+
+  while (1) {
+	ssize_t read_bytes = 0;
+  	IS_SSL_FD(fd)
+  	{
+		idevice_error_t error = idevice_connection_receive(connectionSSL, 
+															my->tmp_buf, 
+															my->tmp_buf_length, 
+															(uint32_t*)&read_bytes);
+		if (error != IDEVICE_E_SUCCESS)
+			break; // SSL_ERROR_WANT_READ ?
+  	}
+	else {
+    	read_bytes = recv(fd, my->tmp_buf, my->tmp_buf_length, RECV_FLAGS);
 	}
-	
-  sm_private_t my = self->private_state;
-  my->curr_recv_fd = fd;
-  
-  
-  while (1) 
-  {
-    ssize_t read_bytes = recv(fd, my->tmp_buf, my->tmp_buf_length, RECV_FLAGS);
     if (read_bytes < 0) 
 	{
 #ifdef WIN32

--- a/src/socket_manager.c
+++ b/src/socket_manager.c
@@ -26,11 +26,19 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
+#include <pthread.h>
 #endif
+
+
+#include <libimobiledevice/libimobiledevice.h>
+#include <libimobiledevice/service.h>
+#include <time.h>
+
 
 #include "char_buffer.h"
 #include "socket_manager.h"
 #include "hash_table.h"
+
 
 #if defined(__MACH__) || defined(WIN32)
 #define SIZEOF_FD_SET sizeof(struct fd_set)
@@ -39,6 +47,33 @@
 #define SIZEOF_FD_SET sizeof(fd_set)
 #define RECV_FLAGS MSG_DONTWAIT
 #endif
+
+// SSL based communication types import 
+#define SSL_ERROR_NONE				0
+#define SSL_ERROR_SSL				1
+#define SSL_ERROR_WANT_READ			2
+#define SSL_ERROR_WANT_WRITE		3
+#define SSL_ERROR_WANT_X509_LOOKUP	4
+#define SSL_ERROR_SYSCALL			5 /* look at error stack/return value/errno */
+#define SSL_ERROR_ZERO_RETURN		6
+#define SSL_ERROR_WANT_CONNECT		7
+#define SSL_ERROR_WANT_ACCEPT		8
+
+enum connection_type {
+	CONNECTION_USBMUXD = 1
+};
+
+struct idevice_connection_private {
+	char *udid;  // added in v1.1.6
+	enum connection_type type;
+	void *data;
+	void *ssl_data;
+};
+
+extern idevice_connection_t connectionSSL;
+#define IS_SSL_FD(fd) if(connectionSSL!=NULL && (fd == (int)(long)connectionSSL->data))
+
+// SSL based communication types import 
 
 struct sm_private {
   struct timeval timeout;
@@ -373,8 +408,22 @@ sm_status sm_remove_fd(sm_t self, int fd) {
   return ret;
 }
 
-sm_status sm_send(sm_t self, int fd, const char *data, size_t length,
-    void* value) {
+sm_status sm_send(sm_t self, int fd, const char *data, size_t length, void* value) 
+{
+	IS_SSL_FD(fd)
+	{
+		uint32_t sent_bytes = 0;
+		if( idevice_connection_send(connectionSSL, data, length, &sent_bytes) !=  IDEVICE_E_SUCCESS)
+		{
+			// wait 200 msec...
+			usleep(200 *1000); // SSL_ERROR_WANT_WRITE? - to do expose the SSL error by libimobiledevice hedaer...
+			if( idevice_connection_send(connectionSSL, data, length, &sent_bytes) !=  IDEVICE_E_SUCCESS)
+				return SM_ERROR; // SSL_ERROR_SSL??? 
+			
+		}
+		return SM_SUCCESS; 
+	}
+			
   sm_private_t my = self->private_state;
   sm_sendq_t sendq = (sm_sendq_t)ht_get_value(my->fd_to_sendq, HT_KEY(fd));
   const char *head = data;
@@ -532,12 +581,43 @@ void sm_resend(sm_t self, int fd) {
   }
 }
 
-void sm_recv(sm_t self, int fd) {
+
+void sm_recv_SSL(sm_t self,int fd)
+{
+	sm_private_t my = self->private_state;
+	while (1)
+	{
+		ssize_t read_bytes = 0;
+		idevice_error_t error = idevice_connection_receive(connectionSSL, my->tmp_buf, my->tmp_buf_length, (uint32_t*)&read_bytes);
+		if (error != IDEVICE_E_SUCCESS)
+			break;
+		
+		void *value = ht_get_value(my->fd_to_value, HT_KEY(fd));
+		if (read_bytes == 0 || self->on_recv(self, fd, value, my->tmp_buf, read_bytes))
+			break;
+	}
+
+	my->curr_recv_fd = 0;
+}
+
+ 
+void sm_recv(sm_t self, int fd) 
+{
+	
+	IS_SSL_FD(fd)
+	{
+		return sm_recv_SSL(self,fd);
+	}
+	
   sm_private_t my = self->private_state;
   my->curr_recv_fd = fd;
-  while (1) {
+  
+  
+  while (1) 
+  {
     ssize_t read_bytes = recv(fd, my->tmp_buf, my->tmp_buf_length, RECV_FLAGS);
-    if (read_bytes < 0) {
+    if (read_bytes < 0) 
+	{
 #ifdef WIN32
       if (WSAGetLastError() != WSAEWOULDBLOCK) {
         fprintf(stderr, "recv failed with error %d\n", WSAGetLastError());
@@ -558,6 +638,7 @@ void sm_recv(sm_t self, int fd) {
     }
   }
   my->curr_recv_fd = 0;
+ 
 }
 
 int sm_select(sm_t self, int timeout_secs) {

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -32,6 +32,7 @@ typedef int8_t ws_state;
 #define STATE_CLOSED 7
 
 
+
 struct ws_private {
   ws_state state;
 


### PR DESCRIPTION
As of iOS 13, Apple requires SSL connection with Web inspector. 
Changes tested on Mac OS X Mojave (libimobiledevice master) with latest appium server on an iPhone running iOS 13 beta 3.