### PR TITLE
fix build with libplist 2.3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,11 @@ AC_DEFINE_UNQUOTED([LIBIMOBILEDEVICE_VERSION], ["$libimobiledevice_version"], [ 
 AC_DEFINE_UNQUOTED([LIBPLIST_VERSION], ["$libplist_version"], [ ])
 AC_DEFINE_UNQUOTED([LIBUSBMUXD_VERSION], ["$libusbmuxd_version"], [ ])
 
+[libplist_version_major=`expr "$libplist_version" : '\([0-9]*\)'`]
+[libplist_version_minor=`expr "$libplist_version" : '[0-9]*\.\([0-9]*\)'`]
+AC_DEFINE_UNQUOTED([LIBPLIST_VERSION_MAJOR], [$libplist_version_major], [ ])
+AC_DEFINE_UNQUOTED([LIBPLIST_VERSION_MINOR], [$libplist_version_minor], [ ])
+
 # Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_RESOLV

--- a/src/idevice_ext.c
+++ b/src/idevice_ext.c
@@ -33,7 +33,11 @@ int read_pair_record(const char *udid, plist_t *pair_record) {
   }
 
   *pair_record = NULL;
+#if LIBPLIST_VERSION_MAJOR >= 2 && LIBPLIST_VERSION_MINOR >= 3
+  plist_from_memory(record_data, record_size, pair_record, NULL);
+#else
   plist_from_memory(record_data, record_size, pair_record);
+#endif
   free(record_data);
 
   if (!*pair_record) {


### PR DESCRIPTION
libplist Version 2.3.0 has breaking change in function plist_from_memory()

https://github.com/libimobiledevice/libplist/blob/50255a2e2573b1299010cfcf49021f72290219b3/NEWS#L20-L21
> - Breaking:
>   * plist_from_memory() gets additional parameter

Closes #398