### PR TITLE
Fix ssl socket resend

### DIFF
--- a/src/idevice_ext.c
+++ b/src/idevice_ext.c
@@ -122,6 +122,8 @@ int idevice_ext_connection_enable_ssl(const char *device_id, int fd, SSL **to_se
 
   SSL_set_connect_state(ssl);
   SSL_set_verify(ssl, 0, NULL);
+  SSL_set_mode(ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
+  SSL_set_mode(ssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
   SSL_set_bio(ssl, ssl_bio, ssl_bio);
 
   int ssl_error = 0;


### PR DESCRIPTION
Set 2 flags for ssl connection:
- `SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER` needed to properly support `sm_resend`, since buffer gets copied to new location for retries
- `SSL_MODE_ENABLE_PARTIAL_WRITE` writes message in ~16kb chunks, which is more in line with current non-blocking architecture (basically imitates the behaviour of write())

Fixes https://github.com/google/ios-webkit-debug-proxy/issues/344