### PR TITLE
Ignore sigpipe signals

### DIFF
--- a/src/ios_webkit_debug_proxy_main.c
+++ b/src/ios_webkit_debug_proxy_main.c
@@ -67,6 +67,9 @@ static void on_signal(int sig) {
 int main(int argc, char** argv) {
   signal(SIGINT, on_signal);
   signal(SIGTERM, on_signal);
+#ifndef WIN32
+  signal(SIGPIPE, SIG_IGN);
+#endif
 
 #ifdef WIN32
   WSADATA wsa_data;


### PR DESCRIPTION
Ignore on unix platforms. This is to void app crashes when remote party, usbmuxd in our case terminates the socket.

Closes https://github.com/google/ios-webkit-debug-proxy/issues/410